### PR TITLE
feat: auto refresh whatsapp qr modal

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,15 +1,18 @@
 import { Image } from "expo-image";
+import { useState } from "react";
 import { Button, Platform, StyleSheet } from "react-native";
 
 import { HelloWave } from "@/components/HelloWave";
 import ParallaxScrollView from "@/components/ParallaxScrollView";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
+import QRModal from "@/components/WhatsAppQRModal";
 import { useAuth } from "@/contexts/AuthContext";
 import { router } from "expo-router";
 
 export default function HomeScreen() {
   const { signOut } = useAuth();
+  const [qrVisible, setQrVisible] = useState(false);
 
   function handleSignOut() {
     signOut();
@@ -66,8 +69,18 @@ export default function HomeScreen() {
         </ThemedText>
       </ThemedView>
       <ThemedView style={styles.stepContainer}>
+        <Button
+          title="Abrir QR do WhatsApp"
+          onPress={() => setQrVisible(true)}
+        />
+      </ThemedView>
+      <ThemedView style={styles.stepContainer}>
         <Button title="Sign Out" onPress={handleSignOut} />
       </ThemedView>
+      <QRModal
+        visible={qrVisible}
+        onClose={() => setQrVisible(false)}
+      />
     </ParallaxScrollView>
   );
 }

--- a/components/WhatsAppQRModal.tsx
+++ b/components/WhatsAppQRModal.tsx
@@ -15,11 +15,22 @@ function WhatsAppQRModal({ visible, onClose }: WhatsAppQRModalProps) {
   const countdownInterval = useRef<NodeJS.Timeout | null>(null);
 
   async function generateQRCode() {
-    setLoading(true);
-    const newUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${Date.now()}`;
-    setQrUrl(newUrl);
-    setCountdown(25);
-    setLoading(false);
+    try {
+      setLoading(true);
+      const baseUrl = process.env.EXPO_PUBLIC_API_URL ?? "";
+      const response = await fetch(`${baseUrl}/whatsapp/qr-code`);
+      const data = await response.json();
+      const code = data.qr || data.qrCode || data.qrcode || data.image;
+      const formatted = code?.startsWith("data:")
+        ? code
+        : `data:image/png;base64,${code}`;
+      setQrUrl(formatted ?? null);
+      setCountdown(25);
+    } catch (err) {
+      console.error("Erro ao gerar QRCode do WhatsApp", err);
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {

--- a/components/WhatsAppQRModal.tsx
+++ b/components/WhatsAppQRModal.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from "react";
+import { ActivityIndicator, Button, Image, Modal, StyleSheet, Text, View } from "react-native";
+
+interface WhatsAppQRModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function WhatsAppQRModal({ visible, onClose }: WhatsAppQRModalProps) {
+  const [qrUrl, setQrUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [countdown, setCountdown] = useState(25);
+
+  const refreshInterval = useRef<NodeJS.Timeout | null>(null);
+  const countdownInterval = useRef<NodeJS.Timeout | null>(null);
+
+  async function generateQRCode() {
+    setLoading(true);
+    const newUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${Date.now()}`;
+    setQrUrl(newUrl);
+    setCountdown(25);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    if (visible) {
+      generateQRCode();
+      refreshInterval.current = setInterval(generateQRCode, 25000);
+      countdownInterval.current = setInterval(() => {
+        setCountdown((prev) => (prev > 0 ? prev - 1 : 0));
+      }, 1000);
+    }
+    return () => {
+      if (refreshInterval.current) clearInterval(refreshInterval.current);
+      if (countdownInterval.current) clearInterval(countdownInterval.current);
+      setCountdown(25);
+    };
+  }, [visible]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          {loading ? (
+            <ActivityIndicator size="large" />
+          ) : (
+            <Image source={{ uri: qrUrl ?? undefined }} style={styles.qr} />
+          )}
+          <Text style={styles.countdown}>Atualizando em: {countdown}s</Text>
+          <Button title="Fechar" onPress={onClose} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  container: {
+    backgroundColor: "white",
+    padding: 20,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  qr: {
+    width: 200,
+    height: 200,
+    marginBottom: 16,
+  },
+  countdown: {
+    marginVertical: 8,
+  },
+});
+
+export default WhatsAppQRModal;


### PR DESCRIPTION
## Summary
- add WhatsAppQRModal component that refreshes QR code every 25 seconds with countdown and loading state
- wire home screen button to open modal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4830cd534832a9889b5ab0347cf4a