### PR TITLE
feat: connect login via MQTT session code

### DIFF
--- a/lib/mqtt.ts
+++ b/lib/mqtt.ts
@@ -1,0 +1,29 @@
+import mqtt, { MqttClient } from 'mqtt';
+
+let mqttClient: MqttClient | null = null;
+let mqttClientRefCount = 0;
+
+export function getMqttClient() {
+  if (mqttClient && mqttClient.connected) {
+    mqttClientRefCount++;
+    return mqttClient;
+  }
+  if (!mqttClient || mqttClient.disconnected) {
+    mqttClient = mqtt.connect(String(process.env.EXPO_PUBLIC_MQTT_URL), {
+      username: String(process.env.EXPO_PUBLIC_MQTT_USERNAME),
+      password: String(process.env.EXPO_PUBLIC_MQTT_PASSWORD),
+    });
+    mqttClientRefCount = 1;
+  }
+  return mqttClient;
+}
+
+export function releaseMqttClient() {
+  if (mqttClientRefCount > 0) {
+    mqttClientRefCount--;
+    if (mqttClientRefCount === 0 && mqttClient) {
+      mqttClient.end();
+      mqttClient = null;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "mqtt": "^5.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add MQTT client helper to manage shared connection
- connect login screen to session via MQTT and navigate on success
- declare mqtt dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a88ece9d5c832ab47ff172504e2811